### PR TITLE
Haskell data from R package 'boot'.

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -1,0 +1,21 @@
+import Numeric.Datasets (getDataset)
+import Numeric.Datasets.Iris (iris)
+import Numeric.Datasets.Abalone (abalone)
+import Numeric.Datasets.Coal (coal)
+
+main = do
+
+  -- The Iris data set is embedded
+  print (length iris)
+  print (head iris)
+
+  -- The Abalone dataset is fetched
+  abas <- getDataset abalone
+  print (length abas)
+  print (head abas)
+
+  -- The Coal dataset is fetched
+  cs <- getDataset coal
+  print (length cs)
+  print (head cs)
+

--- a/src/Numeric/Datasets/Coal.hs
+++ b/src/Numeric/Datasets/Coal.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DeriveGeneric, OverloadedStrings                   #-}
+{-# LANGUAGE GADTs, QuasiQuotes, ViewPatterns, FlexibleContexts #-}
+
+{-|
+
+Abalone data set
+
+UCI ML Repository link <https://archive.ics.uci.edu/ml/datasets/abalone>
+
+-}
+
+module Numeric.Datasets.Coal ( Coal, coal, date ) where
+
+import qualified H.Prelude as H
+import Language.R.QQ
+
+import qualified Foreign.R as R
+
+import Language.R.HExp ( hexp )
+import Language.R.HExp ( HExp(..) )
+
+import qualified Data.Vector.SEXP as V
+
+import Numeric.Datasets
+
+import Data.Csv
+import GHC.Generics
+
+data Coal = Coal
+  { date :: Double
+  } deriving (Show, Read, Generic)
+
+instance FromRecord Coal
+
+coal_r :: IO [Double]
+coal_r = H.runRegion $ do
+  [r| library('boot') |]
+  (hexp -> Real v) <- R.cast R.SReal <$>
+                      [r| coal$date |]
+  return $ V.toList v
+
+coal :: Dataset Coal
+coal = const ((fmap . fmap) Coal coal_r)


### PR DESCRIPTION
I am about to use the coal dataset from `boot`: https://stat.ethz.ch/R-manual/R-devel/library/boot/html/coal.html so I thought I would add it to `datasets` *but* you need `R`, the `R` `boot` library and `inline-r` installed which seems overkill to add to the dependencies. Should we just store the data as a CSV file using my little script? Maybe have a stanza in the .cabal that builds an exe and creates the CSV file with a flag `-reconstructData`? Then the data set can be reconstructed if you want to go to the horse's mouth and you don't mind all the dependencies but normally this flag would be off and no dependencies would be required.